### PR TITLE
support native deploy for bc and bsc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Before proceeding to the next steps, please ensure that the following packages a
 - minikube: 1.29.0
 - docker: 20.10.22
 - kubectl: 1.26.1
+- expect
 
 ## Quick Start
 1. Clone this repository
@@ -96,4 +97,35 @@ kubectl set image statefulset/bc-node-0 bc=ghcr.io/bnb-chain/node:0.10.6 -n bc
 
 kubectl set image statefulset/bsc-node-0 bsc=ghcr.io/bnb-chain/bsc:1.1.18_hf -n bsc
 ...
+```
+
+#### Native deploy for bc and bsc
+1. set providers addr in oracle_relayer.template and oracle_relayer.template
+```bash
+    bc-node.bc.svc.cluster.local    --> your local ip, sunch as 192.168.0.100
+    bsc-node.bsc.svc.cluster.local  --> your local ip, sunch as 192.168.0.100
+```
+
+2. Similar to process in Quick Start, difference as following
+```bash
+    bash +x ./setup_bc_node.sh init // support only one node
+    bash +x ./setup_bc_node.sh native_start // can re-entry
+
+    bash +x ./setup_bsc_node.sh register
+    bash +x ./setup_bsc_node.sh generate
+    bash +x ./setup_bsc_node.sh native_start // can re-entry
+
+    bash +x ./setup_oracle_relayer.sh docker
+    bash +x ./setup_oracle_relayer.sh install_k8s
+
+    bash +x ./setup_bsc_relayer.sh docker
+    bash +x ./setup_bsc_relayer.sh install_k8s
+```
+
+3. stop nodes
+```bash
+    bash +x ./setup_bc_node.sh native_stop 
+    bash +x ./setup_bsc_node.sh native_stop
+    bash +x ./setup_oracle_relayer.sh uninstall_k8s
+    bash +x ./setup_bsc_relayer.sh uninstall_k8s
 ```

--- a/create_bls_key.sh
+++ b/create_bls_key.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/expect
+# 6 num wanted
+set wallet_password 123456 
+# 10 characters at least wanted
+set account_password 1234567890
+
+set timeout 5
+spawn ./bin/geth-ff bls account new --datadir [lindex $argv 0]
+expect "*assword:*"
+send "$wallet_password\r"
+expect "*assword:*"
+send "$wallet_password\r"
+expect "*assword:*"
+send "$account_password\r"
+expect "*assword:*"
+send "$account_password\r"
+expect EOF

--- a/setup_bc_node.sh
+++ b/setup_bc_node.sh
@@ -3,7 +3,12 @@ basedir=$(cd `dirname $0`; pwd)
 workspace=${basedir}
 source ${workspace}/.env
 source ${workspace}/utils.sh
-size=$((${CLUSTER_SIZE}))
+size=$((${BBC_CLUSTER_SIZE}))
+
+function exit_previous() {
+	# stop client
+    ps -ef  | grep bnbchaind | grep start |awk '{print $2}' | xargs kill
+}
 
 function init() {
     rm -rf ${workspace}/.local/bc/*
@@ -147,7 +152,27 @@ uninstall_k8s)
     uninstall_k8s
     echo "===== end ===="
     ;;
+native_start) #only start node0!
+    if [ ${BBC_CLUSTER_SIZE} -ne 1 ];then
+        echo "native_start only support one node, please re-init with BBC_CLUSTER_SIZE=1"
+        exit
+    fi
+    echo "===== stop native node0===="
+    exit_previous
+    sleep 5
+    echo "===== stop native node0 end ===="
+
+    echo "===== start native node0 ===="
+    nohup ${workspace}/bin/bnbchaind start --home ${workspace}/.local/bc/node0 >> ${workspace}/.local/bc/node0/bc.log 2>&1 &
+    echo "===== start native node0 end ===="
+    ;;
+native_stop)
+    echo "===== stop native node0===="
+    exit_previous
+    sleep 5
+    echo "===== stop native node0 end ===="
+    ;;
 *)
-    echo "Usage: setup_bc_node.sh init | install_k8s | uninstall_k8s"
+    echo "Usage: setup_bc_node.sh init | install_k8s | uninstall_k8s ｜ native_start | native_stop"
     ;;
 esac


### PR DESCRIPTION
Ritional:
1.  support native deploy bc and bsc with little code added
2. support native run bsc after bep126 with bls wallet, disable by default, can enable it by setting native_need_bls=true

Usage:
<img width="713" alt="image" src="https://user-images.githubusercontent.com/7995985/219354927-e3359ad0-ab54-4a71-8e87-05a1f3a6d86c.png">
