### PR TITLE
fix and complete deploy workflow with latest version of modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@
 /bsc-relayer/
 /bin/geth
 /bin/bnbchaind
-/bin/bnbcli
+/bin/tbnbcli
 /bin/tool
 /bin/bootnode

--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ Before proceeding to the next steps, please ensure that the following packages a
 - solc: 0.6.4
 - nodejs: 12.18.3 
 - npm: 6.14.6
-- helm: 3.9.4
 - go: 1.18
+- expect
+- jq
+If you would setup nodes on k8s environment, the following packages and softwares are neccessary:
+- helm: 3.9.4
 - minikube: 1.29.0
 - docker: 20.10.22
 - kubectl: 1.26.1
-- expect
+
 
 ## Quick Start
 1. Clone this repository
@@ -24,7 +27,7 @@ git clone https://github.com/bnb-chain/node-deploy.git
 git submodule update --init --recursive
 ```
 
-3. Make `geth`, `bootnode`, `bnbchaind`, `bnbcli` binary files, and put them into `bin/` folder.
+3. Make `geth`, `bootnode`, `bnbchaind`, `tbnbcli` binary files, and put them into `bin/` folder.
 ```bash
 git clone https://github.com/bnb-chain/bsc.git
 cd bsc && make geth
@@ -35,22 +38,24 @@ cp ./build/bin/bootnode ../bin/bootnode
 
 git clone https://github.com/bnb-chain/node.git
 cd node && make build
-cp ./build/bnbcli ../bin/bnbcli
+cp ./build/tbnbcli ../bin/tbnbcli
 cp ./build/bnbchaind ../bin/bnbchaind
+
+git clone git@github.com:bnb-chain/test-crosschain-transfer.git
+cd test-crosschain-transfer && go build
+cp ./test-crosschain-transfer ../bin/test-crosschain-transfer
 ```
 
 4. Make `tool` binary
 ```bash
 make tool
 ```
-
-5. Start local Kubernetes cluster
+5. Setup all nodes.
+two different ways, choose as you like.
 ```bash
+#on k8s environment
 minikube start
-```
 
-6. Setup all nodes on k8s environment
-```bash
 bash +x ./setup_bc_node.sh init
 bash +x ./setup_bc_node.sh install_k8s
 kubectl port-forward svc/bc-node-0 26657:26657 -n bc
@@ -58,6 +63,7 @@ kubectl port-forward svc/bc-node-0 26657:26657 -n bc
 bash +x ./setup_bsc_node.sh register
 bash +x ./setup_bsc_node.sh generate
 bash +x ./setup_bsc_node.sh install_k8s
+kubectl -n bsc port-forward svc/bsc-node-0 8545:8545
 
 bash +x ./setup_oracle_relayer.sh docker
 bash +x ./setup_oracle_relayer.sh install_k8s
@@ -65,24 +71,48 @@ bash +x ./setup_oracle_relayer.sh install_k8s
 bash +x ./setup_bsc_relayer.sh docker
 bash +x ./setup_bsc_relayer.sh install_k8s
 ```
-
-7. Execute cross chain transaction by sending BNB from BC to BSC
 ```bash
+#native deploy without docker
+rm -rf .local
+
+bash +x ./setup_bc_node.sh native_init // support only one node
+bash +x ./setup_bc_node.sh native_start // can re-entry
+
+bash +x ./setup_bsc_node.sh native_init
+bash +x ./setup_bsc_node.sh native_start // can re-entry
+
+bash +x ./setup_bsc_relayer.sh native_init
+bash +x ./setup_bsc_relayer.sh native_start // can re-entry
+
+bash +x ./setup_oracle_relayer.sh native_init
+bash +x ./setup_oracle_relayer.sh native_start // can re-entry
+```
+
+6. Execute cross chain transaction by sending BNB from BC to BSC
+```bash
+## 0x9fB29AAc15b9A4B7F17c3385939b007540f4d791 is the address used by test-crosschain-transfer as sender
 ## macos
-echo "12345678" | ./bin/bnbcli bridge transfer-out --amount 50000:BNB --expire-time $(date -v+300S +%s) --to 0x96D904C0e47e6477C4416369a9858f6E57B317eC  --from node0-delegator --chain-id Binance-Chain-Nile --node localhost:26657 --home ./.local/bc/node0
+echo "12345678" | ./bin/tbnbcli bridge transfer-out --amount 500000000:BNB --expire-time $(date -v+300S +%s) --to 0x9fB29AAc15b9A4B7F17c3385939b007540f4d791  --from node0-delegator --chain-id Binance-Chain-Nile --node localhost:26657 --home ./.local/bc/node0
 
 ## linux
-echo "12345678" | ./bin/bnbcli bridge transfer-out --amount 50000:BNB --expire-time $(date --date="+300 seconds" +%s) --to 0x96D904C0e47e6477C4416369a9858f6E57B317eC  --from local-user --chain-id Binance-Chain-Nile --node localhost:26657
+echo "12345678" | ./bin/tbnbcli bridge transfer-out --amount 500000000:BNB --expire-time $(date --date="+300 seconds" +%s) --to 0x9fB29AAc15b9A4B7F17c3385939b007540f4d791  --from local-user --chain-id Binance-Chain-Nile --node localhost:26657
 ```
 
-8. Enable port forwarding
+7. Check the account balance
 ```
-kubectl -n bsc port-forward svc/bsc-node-0 8545:8545
+curl -X POST "http://localhost:8545" -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x9fB29AAc15b9A4B7F17c3385939b007540f4d791", "latest"],"id":1}' 
+```
+
+8. Execute cross chain transaction by sending BNB from BSC to BC
+```
+
+ ./bin/test-crosschain-transfer --amount 1 --rpc-url http://localhost:8545 --to 0x0cdce3d8d17c0553270064cee95c73f17534d5a0
 ```
 
 9. Check the account balance
-```
-curl -X POST "http://127.0.0.1:8545" -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x96D904C0e47e6477C4416369a9858f6E57B317eC", "latest"],"id":1}' 
+``` bash
+## The bech32 format of 0x0cdce3d8d17c0553270064cee95c73f17534d5a0 is tbnb1pnww8kx30sz4xfcqvn8wjhrn796nf4dqshlvlg.(you can use this tool https://slowli.github.io/bech32-buffer/ to do the convert)  
+./bin/tbnbcli account tbnb1pnww8kx30sz4xfcqvn8wjhrn796nf4dqshlvlg --chain-id Binance-Chain-Nile --node localhost:26657 --trust-node
 ```
 
 ## Additional Commands
@@ -95,6 +125,13 @@ bash +x ./setup_oracle_relayer.sh uninstall_k8s
 bash +x ./setup_bsc_relayer.sh uninstall_k8s
 ```
 
+```bash
+bash +x ./setup_bc_node.sh native_stop 
+bash +x ./setup_bsc_node.sh native_stop
+bash +x ./setup_bsc_relayer.sh native_stop
+bash +x ./setup_oracle_relayer.sh native_stop
+```
+
 #### Upgrade image
 ```bash
 kubectl set image statefulset/bc-node-0 bc=ghcr.io/bnb-chain/node:0.10.6 -n bc
@@ -102,35 +139,4 @@ kubectl set image statefulset/bc-node-0 bc=ghcr.io/bnb-chain/node:0.10.6 -n bc
 
 kubectl set image statefulset/bsc-node-0 bsc=ghcr.io/bnb-chain/bsc:1.1.18_hf -n bsc
 ...
-```
-
-#### Native deploy for bc and bsc
-1. set providers addr in oracle_relayer.template and oracle_relayer.template
-```bash
-    bc-node.bc.svc.cluster.local    --> your local ip, sunch as 192.168.0.100
-    bsc-node.bsc.svc.cluster.local  --> your local ip, sunch as 192.168.0.100
-```
-
-2. Similar to process in Quick Start, difference as following
-```bash
-    bash +x ./setup_bc_node.sh init // support only one node
-    bash +x ./setup_bc_node.sh native_start // can re-entry
-
-    bash +x ./setup_bsc_node.sh register
-    bash +x ./setup_bsc_node.sh generate
-    bash +x ./setup_bsc_node.sh native_start // can re-entry
-
-    bash +x ./setup_oracle_relayer.sh docker
-    bash +x ./setup_oracle_relayer.sh install_k8s
-
-    bash +x ./setup_bsc_relayer.sh docker
-    bash +x ./setup_bsc_relayer.sh install_k8s
-```
-
-3. stop nodes
-```bash
-    bash +x ./setup_bc_node.sh native_stop 
-    bash +x ./setup_bsc_node.sh native_stop
-    bash +x ./setup_oracle_relayer.sh uninstall_k8s
-    bash +x ./setup_bsc_relayer.sh uninstall_k8s
 ```

--- a/bsc_relayer.template
+++ b/bsc_relayer.template
@@ -12,7 +12,7 @@
       "mnemonic_type": "local_mnemonic",
       "aws_region": "",
       "aws_secret_name": "",
-      "mnemonic": {{bbc_mnemonic}},
+      "mnemonic": "",
       "sleep_millisecond_for_wait_block": 500,
       "clean_up_block_interval": 20,
       "block_interval_for_clean_up_undelivered_packages": 1000,

--- a/create_bls_key.sh
+++ b/create_bls_key.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/expect
 # 6 num wanted
-set wallet_password 123456 
+set wallet_password 12345678 
 # 10 characters at least wanted
 set account_password 1234567890
 
 set timeout 5
-spawn ./bin/geth-ff bls account new --datadir [lindex $argv 0]
+spawn ./bin/geth bls account new --datadir [lindex $argv 0]
 expect "*assword:*"
 send "$wallet_password\r"
 expect "*assword:*"

--- a/helm/bsc-relayer/templates/deployment.yaml
+++ b/helm/bsc-relayer/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["./bsc-relayer", "--bbc-network-type", "1", "--config-type", "local", "--config-path", "/data/config/bsc_relayer.json"]
+          command: ["./bsc-relayer", "--bbc-network-type", "0", "--config-type", "local", "--config-path", "/data/config/bsc_relayer.json"]
           ports:
             - name: http
               containerPort: 8090

--- a/helm/oracle-relayer/templates/deployment.yaml
+++ b/helm/oracle-relayer/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["./relayer", "--bbc-network", "1", "--config-type", "local", "--config-path", "/data/config/oracle_relayer.json"]
+          command: ["./relayer", "--bbc-network", "0", "--config-type", "local", "--config-path", "/data/config/oracle_relayer.json"]
           ports:
             - name: http
               containerPort: 8185

--- a/setup_bsc_relayer.sh
+++ b/setup_bsc_relayer.sh
@@ -2,6 +2,18 @@
 basedir=$(cd `dirname $0`; pwd)
 workspace=${basedir}
 
+function exit_previous() {
+	# stop client
+    ps -ef | grep bsc-relayer  | grep config |awk '{print $2}' | xargs kill
+}
+
+function build_relayer() {
+    rm -rf bsc-relayer
+    git clone https://github.com/bnb-chain/bsc-relayer
+    cd bsc-relayer
+    make build
+}
+
 function prepare_docker_image() {
     rm -rf bsc-relayer
     git clone https://github.com/bnb-chain/bsc-relayer
@@ -9,20 +21,28 @@ function prepare_docker_image() {
     docker build . -t bsc-relayer
 }
 
-function prepare_k8s_config() {
-    mnemonic=$(cat ${workspace}/.local/bc/node0/node.info | jq .app_message.secret)
-
+function init_config(){
     mkdir -p ${workspace}/.local/relayer/
     rm -rf ${workspace}/.local/relayer/bsc_relayer.*
-    cp bsc_relayer.template ${workspace}/.local/relayer/bsc_relayer.json
+    cp ${workspace}/bsc_relayer.template ${workspace}/.local/relayer/bsc_relayer.json
     sed -i -e "s/{{bsc_chain_id}}/${BSC_CHAIN_ID}/g" ${workspace}/.local/relayer/bsc_relayer.json
-    sed -i -e "s/{{bbc_mnemonic}}/${mnemonic}/g" ${workspace}/.local/relayer/bsc_relayer.json
     sed -i -e "s/{{private_key}}/${INIT_HOLDER_PRV}/g" ${workspace}/.local/relayer/bsc_relayer.json
+}
 
+function prepare_k8s_config() {
+    init_config
     kubectl create ns relayer
     kubectl delete configmap bsc-relayer -n relayer
     kubectl create configmap bsc-relayer -n relayer \
      --from-file ${workspace}/.local/relayer/bsc_relayer.json
+}
+
+function prepare_native_config() {
+    init_config
+    LAN_IP=$(ifconfig |grep 192.168 |awk -F" " '{print $2}')
+    sed -i -e "s/bc-node-0.bc.svc.cluster.local/${LAN_IP}/g" ${workspace}/.local/relayer/bsc_relayer.json
+    sed -i -e "s/bsc-node-0.bsc.svc.cluster.local/${LAN_IP}/g" ${workspace}/.local/relayer/bsc_relayer.json 
+    sed -i -e "s:/data/relayer.db:${workspace}/.local/relayer/bsc_relayer.db:g" ${workspace}/.local/relayer/bsc_relayer.json 
 }
 
 function install_k8s() {
@@ -55,7 +75,30 @@ uninstall_k8s)
     uninstall_k8s
     echo "===== end ===="
     ;;
+native_init)
+    echo "===== init ===="
+    build_relayer
+    prepare_native_config
+    echo "===== end ===="
+    ;;
+native_start)
+    echo "===== stop native bsc-relayer===="
+    exit_previous
+    sleep 5
+    echo "===== stop native bsc-relayer end ===="
+
+    echo "===== start native node0 ===="
+    cp ${workspace}/bsc-relayer/build/bsc-relayer ${workspace}/.local/relayer/
+    nohup ${workspace}/.local/relayer/bsc-relayer --bbc-network-type 0 --config-type local --config-path ${workspace}/.local/relayer/bsc_relayer.json > ${workspace}/.local/relayer/bsc_relayer.log 2>&1 &
+    echo "===== start native node0 end ===="
+    ;;
+native_stop)
+    echo "===== stop native node0===="
+    exit_previous
+    sleep 5
+    echo "===== stop native node0 end ===="
+    ;;
 *)
-    echo "Usage: setup_bc_node.sh docker | install_k8s | uninstall_k8s"
+    echo "Usage: setup_bc_node.sh docker | install_k8s | uninstall_k8s | native_init | native_start | native_stop"
     ;;
 esac

--- a/setup_oracle_relayer.sh
+++ b/setup_oracle_relayer.sh
@@ -2,6 +2,19 @@
 basedir=$(cd `dirname $0`; pwd)
 workspace=${basedir}
 
+function exit_previous() {
+	# stop client
+    ps -ef  | grep oracle-relayer | grep config |awk '{print $2}' | xargs kill
+}
+
+function build_relayer() {
+    rm -rf oracle-relayer
+    git clone https://github.com/bnb-chain/oracle-relayer
+    cd oracle-relayer
+    make build
+    cd build && mv relayer oracle-relayer
+}
+
 function prepare_docker_image() {
     rm -rf oracle-relayer
     git clone https://github.com/bnb-chain/oracle-relayer
@@ -9,19 +22,30 @@ function prepare_docker_image() {
     make build_docker
 }
 
-function prepare_k8s_config() {
+function init_config(){
     mkdir -p ${workspace}/.local/relayer/
     rm -rf ${workspace}/.local/relayer/oracle_relayer.*
-    cp oracle_relayer.template ${workspace}/.local/relayer/oracle_relayer.json
+    cp ${workspace}/oracle_relayer.template ${workspace}/.local/relayer/oracle_relayer.json
 
     sed -i -e "s/{{bsc_chain_id}}/${BSC_CHAIN_ID}/g" ${workspace}/.local/relayer/oracle_relayer.json
-    mnemonic=$(cat ${workspace}/.local/bc/node0/node.info | jq .app_message.secret)
+    mnemonic="\"$(cat ${workspace}/.local/bc/node0/operator.info |tail  -1)\""
     sed -i -e "s/{{bbc_mnemonic}}/${mnemonic}/g" ${workspace}/.local/relayer/oracle_relayer.json
+}
 
+function prepare_k8s_config() {
+    init_config
     kubectl create ns relayer
     kubectl delete configmap oracle-relayer -n relayer
     kubectl create configmap oracle-relayer -n relayer \
      --from-file ${workspace}/.local/relayer/oracle_relayer.json
+}
+
+function prepare_native_config() {
+    init_config
+    LAN_IP=$(ifconfig |grep 192.168 |awk -F" " '{print $2}')
+    sed -i -e "s/bc-node-0.bc.svc.cluster.local/${LAN_IP}/g" ${workspace}/.local/relayer/oracle_relayer.json
+    sed -i -e "s/bsc-node-0.bsc.svc.cluster.local/${LAN_IP}/g" ${workspace}/.local/relayer/oracle_relayer.json 
+    sed -i -e "s:/data/relayer.db:${workspace}/.local/relayer/oracle_relayer.db:g" ${workspace}/.local/relayer/oracle_relayer.json 
 }
 
 function install_k8s() {
@@ -54,7 +78,30 @@ uninstall_k8s)
     uninstall_k8s
     echo "===== end ===="
     ;;
+native_init)
+    echo "===== init ===="
+    build_relayer
+    prepare_native_config
+    echo "===== end ===="
+    ;;
+native_start)
+    echo "===== stop native oracle-relayer===="
+    exit_previous
+    sleep 5
+    echo "===== stop native oracle-relayer end ===="
+
+    echo "===== start native node0 ===="
+    cp ${workspace}/oracle-relayer/build/oracle-relayer ${workspace}/.local/relayer/
+    nohup ${workspace}/.local/relayer/oracle-relayer --bbc-network 0 --config-type local --config-path ${workspace}/.local/relayer/oracle_relayer.json > ${workspace}/.local/relayer/oracle_relayer.log 2>&1 &
+    echo "===== start native node0 end ===="
+    ;;
+native_stop)
+    echo "===== stop native node0===="
+    exit_previous
+    sleep 5
+    echo "===== stop native node0 end ===="
+    ;;
 *)
-    echo "Usage: setup_bc_node.sh docker | install_k8s | uninstall_k8s"
+    echo "Usage: setup_bc_node.sh docker | install_k8s | uninstall_k8s | native_init | native_start | native_stop"
     ;;
 esac

--- a/tool/main.go
+++ b/tool/main.go
@@ -92,11 +92,15 @@ func main() {
 	flag.Parse()
 
 	if *bech32Addr != "" {
-		addr, err := btypes.AccAddressFromBech32(*bech32Addr)
+		Bech32PrefixAccAddr := "tbnb"
+		if *networkType == 1 {
+			Bech32PrefixAccAddr = "bnb"
+		}
+		bz, err := btypes.GetFromBech32(*bech32Addr, Bech32PrefixAccAddr)
 		if err != nil {
 			fmt.Println(err)
-			return
 		}
+		addr := btypes.AccAddress(bz)
 		fmt.Println(common.BytesToAddress(addr.Bytes()))
 	}
 


### PR DESCRIPTION
Description
1. fix deploy workflow after planck, luban and plato upgrade
2. enable transferring from bsc to bc.

Rationale
1. after planck, luban and plato upgrade, deploy workflow in this repo not work now.
   we can set up a test network as in QA env, by following:
```
  1. bsc, start with genesis@v1.16, without enabling planck upgrade
  2. bc, start without enabling BEP171 and BEP126
  3. bsc-relayer,start old version without supporting BEP171
	  check cross chain from bc to bsc
  4. oracle-relayer, start
	  check cross chain from bsc to bc
  5. bsc, modify RialtoGenesisHash and enable planck upgrade
	  call whitelistInit 
  6. bc, enable BEP171
  7. bsc-relayer, start new version supporting BEP171
	  check cross chain from bc to bsc
  8. bsc, enable luban upgrade
	  check local vote
  9. bc, enable BEP126
	  check isOperator for validator contract and slash contract for systemreward contract
  10. bc, collect info and edit vote addrs for all validators in bsc,
	  wait for breathe block to deliver and wait for next epoch block
	  check justified block
  11. bsc, enable plato upgrade
	  check finalized block
  12. enable vote slash in slash contract by gov
```
It's too complex for human, so we simplify it by following
```
1. upgrade based genesis contracts
     use latest code of master branch
2. avoid to call whitelistInit manually
    call whitelistInit in genesis block
3. not force BEP126 between luban and plato upgrade
     set validator and slash contract  as operators for systemreward contract in genesis block
4. avoid to enable vote slash by gov
    enable vote slash in genesis block.
5. avoid to modify RialtoGenesisHash
6. avoid to switch version of bsc-relayer
    use code contract as genesis which including planck upgrade,
    start bsc-relayer by using latest version in first time
7.  avoid to edit vote addr
    create bsc validator with vote addr 
```

2. enable transferring from bsc to bc
   deps: a. make repo test-crosschain-transfer public 
             b. bnbchaind collect-gentxs support acc-prefix
   and other changes:
```
   1. tbnbcli instead of bnbcli
   2. add test-crosschain-transfer for test
   3. modify bbc_mnemonic in oracle_relayer.json
   4. modify network-type to 0 from 1
   5. make tool accept prefix 'tbnb' and mofify prefix in config.
   ...
```

Example
add an example CLI or API response...

Changes
Notable changes:

add each change in a bullet point here
...