### PR TITLE
support running geth all alone in native mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ bash +x ./setup_bsc_relayer.sh native_stop
 bash +x ./setup_oracle_relayer.sh native_stop
 ```
 
+```bash
+# one cmd to start bsc cluster all alone
+bash +x ./setup_bsc_node.sh native_run_alone
+```
 #### Upgrade image
 ```bash
 kubectl set image statefulset/bc-node-0 bc=ghcr.io/bnb-chain/node:0.10.6 -n bc


### PR DESCRIPTION
Description

support running geth all alone in native mode

Rationale

usually, we just want setup bsc cluster, but with all hardfork enabled as mainnet
setup bc node and relayers are not neccessary

this PR add a cmd to support setting up bsc cluster all alone, and with all hardfork enabled as mainnet

Example
```bash
# justified and finalized block will be formed when the first epoch block passed after enabling luban upgrade 
# ,that is about the 203 block
bash +x ./setup_bsc_node.sh native_run_alone
```

Changes
Notable changes:

add each change in a bullet point here
...