### PR TITLE
force to register validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ cd bsc && make geth
 go build -o ./build/bin/bootnode ./cmd/bootnode
 ```
 
-4. Configure the cluster
+4. build `create-validator`
+
+```bash
+# This tool is used to register the validators into StakeHub.
+cd create-validator
+go build
+```
+
+5. Configure the cluster
 ```
   You can configure the cluster by modifying the following files:
    - `config.toml`
@@ -38,7 +46,7 @@ go build -o ./build/bin/bootnode ./cmd/bootnode
    - `.env`
 ```
 
-5. Setup all nodes.
+6. Setup all nodes.
 two different ways, choose as you like.
 ```bash
 bash -x ./bsc_cluster.sh reset # will reset the cluster and start
@@ -48,7 +56,7 @@ bash -x ./bsc_cluster.sh start [vidx] # only start the cluster
 bash -x ./bsc_cluster.sh restart [vidx] # start the cluster after stopping it
 ```
 
-6. Setup a full node.
+7. Setup a full node.
 If you want to run a full node to test snap/full syncing, you can run:
 
 > Attention: it relies on the validator cluster, so you should set up validators by `bsc_cluster.sh` firstly.
@@ -87,17 +95,4 @@ go build
 cd txblob
 go build
 ./txblob
-```
-
-## Register validators in StakeHub(Optional)
-After bc-fusion, the governance feature is transferred to bsc from bc,
-so register the validators into StakeHub if trying to test the governance.
-
-cd create-validator
-
-go build
-
-switch the flag
-```
-needRegister=true
 ```

--- a/bsc_cluster.sh
+++ b/bsc_cluster.sh
@@ -15,7 +15,6 @@ dbEngine="leveldb"
 gcmode="full"
 epoch=200
 blockInterval=3
-needRegister=false
 sleepBeforeStart=10
 
 # stop geth client
@@ -87,10 +86,10 @@ function prepare_config() {
 
     cd ${workspace}/genesis/
     git checkout HEAD contracts
-    if ${needRegister};then
-        sed -i -e '/registeredContractChannelMap\[VALIDATOR_CONTRACT_ADDR\]\[STAKING_CHANNELID\]/d' ${workspace}/genesis/contracts/deprecated/CrossChain.sol
-        sed -i -e  's/public onlyCoinbase onlyZeroGasPrice {/public onlyCoinbase onlyZeroGasPrice {if (block.number < 30) return;/' ${workspace}/genesis/contracts/BSCValidatorSet.sol
-    fi
+
+    sed -i -e '/registeredContractChannelMap\[VALIDATOR_CONTRACT_ADDR\]\[STAKING_CHANNELID\]/d' ${workspace}/genesis/contracts/CrossChain.sol
+    sed -i -e  's/public onlyCoinbase onlyZeroGasPrice {/public onlyCoinbase onlyZeroGasPrice {if (block.number < 30) return;/' ${workspace}/genesis/contracts/BSCValidatorSet.sol
+    
     poetry run python -m scripts.generate generate-validators
     poetry run python -m scripts.generate generate-init-holders "${initHolders}"
     poetry run python -m scripts.generate dev \
@@ -169,7 +168,7 @@ function native_start() {
             --ws.addr 0.0.0.0 --ws.port ${WSPort} --http.addr 0.0.0.0 --http.port ${HTTPPort} --http.corsdomain "*" \
             --metrics --metrics.addr localhost --metrics.port ${MetricsPort} --metrics.expensive \
             --gcmode ${gcmode} --syncmode full --mine --vote --monitor.maliciousvote \
-            --rialtohash ${rialtoHash} --override.passedforktime ${PassedForkTime} \
+            --rialtohash ${rialtoHash} --override.passedforktime ${PassedForkTime} --override.pascal ${LastHardforkTime} --override.prague ${LastHardforkTime} \
             --override.immutabilitythreshold ${FullImmutabilityThreshold} --override.breatheblockinterval ${BreatheBlockInterval} \
             --override.minforblobrequest ${MinBlocksForBlobRequests} --override.defaultextrareserve ${DefaultExtraReserveForBlobRequests} \
             `# --override.fixedturnlength ${FixedTurnLength}` \

--- a/bsc_fullnode.sh
+++ b/bsc_fullnode.sh
@@ -52,7 +52,7 @@ function start() {
   --ws.addr 0.0.0.0 --ws.port $(( 8600 + $index )) --http.addr 0.0.0.0 --http.port $(( 8600 + $index )) --http.corsdomain "*" \
   --metrics --metrics.addr 0.0.0.0 --metrics.port $(( 6100 + $index )) --metrics.expensive \
   --gcmode $gcmode --syncmode $syncmode --state.scheme ${stateScheme} $extraflags \
-  --rialtohash ${rialtoHash} --override.passedforktime ${PassedForkTime} \
+  --rialtohash ${rialtoHash} --override.passedforktime ${PassedForkTime} --override.pascal ${LastHardforkTime} --override.prague ${LastHardforkTime} \
   --override.immutabilitythreshold ${FullImmutabilityThreshold} --override.breatheblockinterval ${BreatheBlockInterval} \
   --override.minforblobrequest ${MinBlocksForBlobRequests} --override.defaultextrareserve ${DefaultExtraReserveForBlobRequests} \
   > $dst/bsc-node.log 2>&1 &

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,6 @@ NetworkId = 714
 SyncMode = "full"
 NoPruning = false
 NoPrefetch = false
-LightPeers = 100
 DatabaseCache = 512
 DatabaseFreezer = ""
 TrieCleanCache = 256
@@ -44,7 +43,6 @@ Lifetime = 10800000000000
 [Node]
 IPCPath = "geth.ipc"
 HTTPHost = "0.0.0.0"
-NoUSB = true
 InsecureUnlockAllowed = true
 HTTPPort = 8545
 HTTPVirtualHosts = ["*"]


### PR DESCRIPTION
system contract will update at pascal hardfork,
then if no validators registered, `updateValidatorSetV2` will report 'invalid opcode: INVALID'
so force to register validators now