### PR TITLE
fix: add BREATHE_BLOCK_INTERVAL to 1200 to match geth config

### DIFF
--- a/bsc_cluster.sh
+++ b/bsc_cluster.sh
@@ -300,7 +300,7 @@ function start_reth_bsc() {
     fi
     
     # Run reth-bsc node
-    nohup env RUST_LOG=debug ${RETH_BSC_BINARY_PATH} node \
+    nohup env RUST_LOG=debug BREATHE_BLOCK_INTERVAL=${BreatheBlockInterval} ${RETH_BSC_BINARY_PATH} node \
         --chain ${workspace}/.local/node${nodeIndex}/genesis_reth.json \
         --datadir ${workspace}/.local/node${nodeIndex} \
         --genesis-hash ${rialtoHash} \


### PR DESCRIPTION
The local geth uses BreatheBlockInterval=1200 as the BreatheBlockInterval.
Setting BREATHE_BLOCK_INTERVAL=${BreatheBlockInterval}, so that it matches local geth's logic